### PR TITLE
Bump GitBucket to 3.12.0

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -27,7 +27,8 @@ object MyBuild extends Build {
     libraryDependencies ++= Seq(
       "gitbucket"          % "gitbucket-assembly" % "3.8.0" % "provided",
       "com.typesafe.play" %% "twirl-compiler"     % "1.0.4" % "provided",
-      "javax.servlet"      % "javax.servlet-api"  % "3.1.0" % "provided"
+      "javax.servlet"      % "javax.servlet-api"  % "3.1.0" % "provided",
+      "jp.sf.amateras"    %% "scalatra-forms"     % "0.2.0" % "provided"
     ),
     javacOptions in compile ++= Seq("-target", "7", "-source", "7")
   ).enablePlugins(SbtTwirl)

--- a/project/build.scala
+++ b/project/build.scala
@@ -25,10 +25,10 @@ object MyBuild extends Build {
       "amateras-repo" at "http://amateras.sourceforge.jp/mvn/"
     ),
     libraryDependencies ++= Seq(
-      "gitbucket"          % "gitbucket-assembly" % "3.8.0" % "provided",
-      "com.typesafe.play" %% "twirl-compiler"     % "1.0.4" % "provided",
-      "javax.servlet"      % "javax.servlet-api"  % "3.1.0" % "provided",
-      "jp.sf.amateras"    %% "scalatra-forms"     % "0.2.0" % "provided"
+      "gitbucket"          % "gitbucket-assembly" % "3.12.0" % "provided",
+      "com.typesafe.play" %% "twirl-compiler"     % "1.0.4"  % "provided",
+      "javax.servlet"      % "javax.servlet-api"  % "3.1.0"  % "provided",
+      "jp.sf.amateras"    %% "scalatra-forms"     % "0.2.0"  % "provided"
     ),
     javacOptions in compile ++= Seq("-target", "7", "-source", "7")
   ).enablePlugins(SbtTwirl)


### PR DESCRIPTION
GItBucket v3.12.0 has been released.

https://github.com/gitbucket/gitbucket/releases/tag/3.12

Since gitbucket-assembly has been released 3.12.0, I changed libraryDependencies.
